### PR TITLE
Speed up CI with Blacksmith runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -70,7 +70,7 @@ jobs:
 
   e2e-android:
     name: E2E Tests (Android)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Use Blacksmith's faster bare metal runners for unit tests and Android E2E builds. Blacksmith provides 3,000 free minutes/month on 2 vCPU runners and executes builds 2x faster than GitHub's ubuntu-latest at half the cost.

## Changes

- Updated unit-tests job to use `blacksmith-2vcpu-ubuntu-2404`
- Updated e2e-android job to use `blacksmith-2vcpu-ubuntu-2404`
- Left e2e-ios on `macos-15` (Blacksmith doesn't offer macOS runners)

## Setup Required

Before this PR can be merged, authorize Blacksmith at [app.blacksmith.sh](https://www.blacksmith.sh/) for your GitHub account/organization.

## Testing

- Once Blacksmith is authorized, push this PR and verify all 3 CI jobs pass
- If the Android E2E job fails due to KVM issues on bare metal, revert just that job back to ubuntu-latest
- Monitor GitHub Actions to compare build times before/after