### PR TITLE
Fix scan button and snackbar overlapping Android navigation bar

### DIFF
--- a/__tests__/screens/HomeScreen.test.tsx
+++ b/__tests__/screens/HomeScreen.test.tsx
@@ -5,6 +5,11 @@ import { useBookStore } from '@/stores/bookStore';
 import { Book } from '@/types/book';
 import { __mockNavigate } from '../../__mocks__/@react-navigation/native';
 
+jest.mock('react-native-safe-area-context', () => ({
+  ...jest.requireActual('react-native-safe-area-context'),
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
 // Mock GestureHandlerRootView
 jest.mock('react-native-gesture-handler', () => {
   const View = require('react-native').View;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4669,7 +4669,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6590,7 +6590,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -8557,7 +8557,7 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -8,6 +8,7 @@ interface SnackbarProps {
   onDismiss: () => void;
   duration?: number;
   visible: boolean;
+  bottomOffset?: number;
 }
 
 export function Snackbar({
@@ -17,6 +18,7 @@ export function Snackbar({
   onDismiss,
   duration = 4000,
   visible,
+  bottomOffset = 0,
 }: SnackbarProps) {
   const translateY = React.useRef(new Animated.Value(100)).current;
 
@@ -62,7 +64,7 @@ export function Snackbar({
   return (
     <Animated.View
       testID="undo-snackbar"
-      style={[styles.container, { transform: [{ translateY }] }]}
+      style={[styles.container, { bottom: 80 + bottomOffset, transform: [{ translateY }] }]}
     >
       <Text style={styles.message}>{message}</Text>
       {onAction && (
@@ -77,7 +79,6 @@ export function Snackbar({
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    bottom: 80,
     alignSelf: 'center',
     backgroundColor: 'rgba(60, 60, 67, 0.9)',
     borderRadius: 22,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   ActivityIndicator,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import * as Haptics from 'expo-haptics';
 
@@ -32,6 +32,7 @@ interface DeletedBook {
 
 export function HomeScreen() {
   const navigation = useNavigation<any>();
+  const insets = useSafeAreaInsets();
   const { books, isLoading, loadBooks, removeBook, restoreBook } = useBookStore();
   const [deletedBook, setDeletedBook] = useState<DeletedBook | null>(null);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
@@ -98,7 +99,7 @@ export function HomeScreen() {
 
       <TouchableOpacity
         testID="scan-button"
-        style={styles.scanButton}
+        style={[styles.scanButton, { bottom: 24 + insets.bottom }]}
         onPress={handleScanPress}
         activeOpacity={0.8}
         accessible={true}
@@ -115,6 +116,7 @@ export function HomeScreen() {
         onAction={handleUndo}
         onDismiss={handleSnackbarDismiss}
         visible={snackbarVisible}
+        bottomOffset={insets.bottom}
       />
     </SafeAreaView>
   );
@@ -141,7 +143,6 @@ const styles = StyleSheet.create({
   },
   scanButton: {
     position: 'absolute',
-    bottom: 24,
     alignSelf: 'center',
     backgroundColor: '#007AFF',
     paddingHorizontal: 24,


### PR DESCRIPTION
## Problem

Testing on Android revealed that the "Beolvasás" scan button and undo snackbar were positioned too low and overlapping the system navigation buttons. The app renders with `edgeToEdgeEnabled: true` but the `SafeAreaView` only applied insets to the top edge, leaving bottom-positioned elements vulnerable to overlap.

## Solution

Use `useSafeAreaInsets()` from `react-native-safe-area-context` to dynamically offset absolutely-positioned elements from the bottom safe area.

- **HomeScreen.tsx**: Calculate dynamic bottom offset for scan button (`24 + insets.bottom`) and pass `bottomOffset` to the Snackbar
- **Snackbar.tsx**: Accept optional `bottomOffset` prop and apply to inline style
- **Test mock**: Mock `useSafeAreaInsets` to return zero insets for test stability

## Testing

1. Run `npm test` — all 93 tests pass
2. On Android: scan button and snackbar now clear the system navigation bar