### PR TITLE
Fix Android E2E tests in CI

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -8,7 +8,7 @@ module.exports = {
       config: 'e2e/jest.config.js',
     },
     jest: {
-      setupTimeout: 120000,
+      setupTimeout: 300000,
     },
   },
   apps: {
@@ -36,8 +36,10 @@ module.exports = {
     'android.release': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      testBinaryPath:
+        'android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
       build:
-        `cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release -PreactNativeArchitectures=${arch}`,
+        `cd android && ./gradlew assembleRelease :app:assembleDebugAndroidTest -DtestBuildType=debug -PreactNativeArchitectures=${arch}`,
     },
   },
   devices: {

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -1,3 +1,5 @@
+const arch = process.arch === 'arm64' ? 'arm64-v8a' : 'x86_64';
+
 /** @type {Detox.DetoxConfig} */
 module.exports = {
   testRunner: {
@@ -28,14 +30,14 @@ module.exports = {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
       build:
-        'cd android && ./gradlew assembleDebug :app:assembleDebugAndroidTest -DtestBuildType=debug',
+        `cd android && ./gradlew assembleDebug :app:assembleDebugAndroidTest -DtestBuildType=debug -PreactNativeArchitectures=${arch}`,
       reversePorts: [8081],
     },
     'android.release': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
       build:
-        'cd android && ./gradlew assembleRelease :app:assembleDebugAndroidTest -DtestBuildType=debug',
+        `cd android && ./gradlew assembleRelease :app:assembleDebugAndroidTest -DtestBuildType=debug -PreactNativeArchitectures=${arch}`,
     },
   },
   devices: {

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -48,7 +48,7 @@ module.exports = {
     emulator: {
       type: 'android.emulator',
       device: {
-        avdName: 'Pixel_4_API_30',
+        avdName: 'test_emulator_api_30',
       },
     },
   },

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -36,10 +36,8 @@ module.exports = {
     'android.release': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      testBinaryPath:
-        'android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
       build:
-        `cd android && ./gradlew assembleRelease :app:assembleDebugAndroidTest -DtestBuildType=debug -PreactNativeArchitectures=${arch}`,
+        `cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release -PreactNativeArchitectures=${arch}`,
     },
   },
   devices: {

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -8,7 +8,7 @@ module.exports = {
       config: 'e2e/jest.config.js',
     },
     jest: {
-      setupTimeout: 300000,
+      setupTimeout: 120000,
     },
   },
   apps: {
@@ -36,10 +36,8 @@ module.exports = {
     'android.release': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      testBinaryPath:
-        'android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
       build:
-        `cd android && ./gradlew assembleRelease :app:assembleDebugAndroidTest -DtestBuildType=debug -PreactNativeArchitectures=${arch}`,
+        `cd android && ./gradlew assembleRelease :app:assembleAndroidTest -DtestBuildType=release -PreactNativeArchitectures=${arch}`,
     },
   },
   devices: {

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -36,6 +36,8 @@ module.exports = {
     'android.release': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      testBinaryPath:
+        'android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk',
       build:
         `cd android && ./gradlew assembleRelease :app:assembleDebugAndroidTest -DtestBuildType=debug -PreactNativeArchitectures=${arch}`,
     },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: android
-          key: expo-prebuild-android-${{ hashFiles('app.json', 'package-lock.json') }}
+          key: expo-prebuild-android-${{ hashFiles('app.json', 'package-lock.json', 'plugins/**/*.js') }}
 
       - name: Generate native projects
         if: steps.prebuild-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,14 +97,19 @@ jobs:
       - name: Build for Detox
         run: npm run build:e2e:android
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run E2E Tests on Android Emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30
           target: google_apis
           arch: x86_64
-          profile: Pixel 4
-          avd-name: Pixel_4_API_30
+          avd-name: test_emulator_api_30
           script: npm run test:e2e:android
 
       - name: Upload artifacts on failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
@@ -102,6 +101,15 @@ jobs:
       - name: Generate native projects
         if: steps.prebuild-cache.outputs.cache-hit != 'true'
         run: npx expo prebuild --clean
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-
 
       - name: Build for Detox
         run: npm run build:e2e:android

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
@@ -91,7 +92,15 @@ jobs:
       - name: Install Detox CLI
         run: npm install -g detox-cli
 
+      - name: Cache Expo prebuild
+        id: prebuild-cache
+        uses: actions/cache@v4
+        with:
+          path: android
+          key: expo-prebuild-android-${{ hashFiles('app.json', 'package-lock.json') }}
+
       - name: Generate native projects
+        if: steps.prebuild-cache.outputs.cache-hit != 'true'
         run: npx expo prebuild --clean
 
       - name: Build for Detox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
           restore-keys: gradle-
 
       - name: Build for Detox
-        run: npm run build:e2e:android
+        run: cd android && ./gradlew assembleDebug :app:assembleDebugAndroidTest -DtestBuildType=debug -PreactNativeArchitectures=x86_64 -PbundleInDebug
 
       - name: Enable KVM
         run: |
@@ -127,7 +127,7 @@ jobs:
           target: google_apis
           arch: x86_64
           avd-name: test_emulator_api_30
-          script: npm run test:e2e:android
+          script: detox test --configuration android.emu.debug
 
       - name: Upload artifacts on failure
         uses: actions/upload-artifact@v4

--- a/app.json
+++ b/app.json
@@ -39,6 +39,7 @@
       ]
     },
     "plugins": [
+      "./plugins/withDetoxTestBuildType",
       [
         "expo-camera",
         {

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   rootDir: '..',
   testMatch: ['<rootDir>/e2e/**/*.test.ts'],
-  testTimeout: 120000,
+  testTimeout: 300000,
   maxWorkers: 1,
   globalSetup: 'detox/runners/jest/globalSetup',
   globalTeardown: 'detox/runners/jest/globalTeardown',

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   rootDir: '..',
   testMatch: ['<rootDir>/e2e/**/*.test.ts'],
-  testTimeout: 300000,
+  testTimeout: 120000,
   maxWorkers: 1,
   globalSetup: 'detox/runners/jest/globalSetup',
   globalTeardown: 'detox/runners/jest/globalTeardown',

--- a/plugins/withDetoxTestBuildType.js
+++ b/plugins/withDetoxTestBuildType.js
@@ -53,6 +53,14 @@ function withDetoxAppBuildGradle(config) {
       );
     }
 
+    // Detox has product flavors (coreNative, full). Tell Gradle to use 'full'.
+    if (!contents.includes("missingDimensionStrategy 'detox'")) {
+      contents = contents.replace(
+        /defaultConfig\s*\{/,
+        `defaultConfig {\n        missingDimensionStrategy 'detox', 'full'`,
+      );
+    }
+
     // RNGP skips JS bundling for variants in debuggableVariants (default: ['debug']).
     // When -PbundleInDebug is passed, clear the list so debug builds get a JS bundle.
     // Check for actual code assignment, not just comments mentioning debuggableVariants.

--- a/plugins/withDetoxTestBuildType.js
+++ b/plugins/withDetoxTestBuildType.js
@@ -1,0 +1,23 @@
+const { withAppBuildGradle } = require('expo/config-plugins');
+
+/**
+ * Expo config plugin that adds testBuildType support for Detox.
+ *
+ * Without this, Android always builds debug test APKs regardless of
+ * the -DtestBuildType flag. This plugin injects the necessary config
+ * so `./gradlew assembleAndroidTest -DtestBuildType=release` builds
+ * a release test APK that can instrument a release app.
+ */
+module.exports = function withDetoxTestBuildType(config) {
+  return withAppBuildGradle(config, (config) => {
+    const contents = config.modResults.contents;
+    if (contents.includes('testBuildType')) {
+      return config;
+    }
+    config.modResults.contents = contents.replace(
+      /defaultConfig\s*\{/,
+      `defaultConfig {\n        testBuildType System.getProperty('testBuildType', 'debug')`,
+    );
+    return config;
+  });
+};

--- a/plugins/withDetoxTestBuildType.js
+++ b/plugins/withDetoxTestBuildType.js
@@ -21,7 +21,8 @@ module.exports = function withDetoxTestBuildType(config) {
 
     // RNGP skips JS bundling for variants in debuggableVariants (default: ['debug']).
     // When -PbundleInDebug is passed, clear the list so debug builds get a JS bundle.
-    if (!contents.includes('debuggableVariants')) {
+    // Check for actual code assignment, not just comments mentioning debuggableVariants.
+    if (!contents.match(/^\s*debuggableVariants\s*=/m)) {
       contents = contents.replace(
         /react \{/,
         `react {\n    if (project.hasProperty('bundleInDebug')) {\n        debuggableVariants = []\n    }`,

--- a/plugins/withDetoxTestBuildType.js
+++ b/plugins/withDetoxTestBuildType.js
@@ -19,10 +19,11 @@ module.exports = function withDetoxTestBuildType(config) {
       );
     }
 
-    if (!contents.includes('bundleInDebug')) {
+    // RNGP uses a bundleIn map property, not a direct bundleInDebug field
+    if (!contents.includes('bundleIn')) {
       contents = contents.replace(
         /react \{/,
-        `react {\n    bundleInDebug = project.hasProperty('bundleInDebug')`,
+        `react {\n    if (project.hasProperty('bundleInDebug')) {\n        bundleIn = ["debug": true]\n    }`,
       );
     }
 

--- a/plugins/withDetoxTestBuildType.js
+++ b/plugins/withDetoxTestBuildType.js
@@ -1,14 +1,41 @@
-const { withAppBuildGradle } = require('expo/config-plugins');
+const {
+  withAppBuildGradle,
+  withSettingsGradle,
+  withDangerousMod,
+} = require('expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Expo config plugin for Detox Android E2E testing.
  *
- * Adds two capabilities to the generated build.gradle:
- * 1. testBuildType support: allows -DtestBuildType=release to build release test APKs
- * 2. bundleInDebug support: allows -PbundleInDebug to embed the JS bundle in debug
- *    builds, so E2E tests work in CI without a Metro dev server
+ * Injects the full Detox Android setup into the generated native project:
+ * 1. settings.gradle: includes the Detox native project
+ * 2. build.gradle: testBuildType, bundleInDebug, test runner, and Detox dependency
+ * 3. DetoxTest.java: the instrumentation test class Detox needs to communicate with the app
  */
 module.exports = function withDetoxTestBuildType(config) {
+  config = withDetoxSettingsGradle(config);
+  config = withDetoxAppBuildGradle(config);
+  config = withDetoxTestClass(config);
+  return config;
+};
+
+function withDetoxSettingsGradle(config) {
+  return withSettingsGradle(config, (config) => {
+    let contents = config.modResults.contents;
+
+    if (!contents.includes("include ':detox'")) {
+      contents +=
+        "\ninclude ':detox'\nproject(':detox').projectDir = new File(rootProject.projectDir, '../node_modules/detox/android/detox')\n";
+    }
+
+    config.modResults.contents = contents;
+    return config;
+  });
+}
+
+function withDetoxAppBuildGradle(config) {
   return withAppBuildGradle(config, (config) => {
     let contents = config.modResults.contents;
 
@@ -16,6 +43,13 @@ module.exports = function withDetoxTestBuildType(config) {
       contents = contents.replace(
         /defaultConfig\s*\{/,
         `defaultConfig {\n        testBuildType System.getProperty('testBuildType', 'debug')`,
+      );
+    }
+
+    if (!contents.includes('testInstrumentationRunner')) {
+      contents = contents.replace(
+        /defaultConfig\s*\{/,
+        `defaultConfig {\n        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'`,
       );
     }
 
@@ -29,7 +63,69 @@ module.exports = function withDetoxTestBuildType(config) {
       );
     }
 
+    if (!contents.includes("androidTestImplementation(project(':detox'))")) {
+      contents = contents.replace(
+        /dependencies\s*\{/,
+        `dependencies {\n    androidTestImplementation(project(':detox'))`,
+      );
+    }
+
     config.modResults.contents = contents;
     return config;
   });
-};
+}
+
+function withDetoxTestClass(config) {
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const packageName = config.android?.package || 'hu.lepkehalo.app';
+      const packagePath = packageName.replace(/\./g, '/');
+      const testDir = path.join(
+        config.modRequest.platformProjectRoot,
+        'app/src/androidTest/java',
+        packagePath,
+      );
+
+      fs.mkdirSync(testDir, { recursive: true });
+
+      const testFile = path.join(testDir, 'DetoxTest.java');
+      fs.writeFileSync(
+        testFile,
+        `package ${packageName};
+
+import com.wix.detox.Detox;
+import com.wix.detox.config.DetoxConfig;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class DetoxTest {
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityRule =
+            new ActivityTestRule<>(MainActivity.class, false, false);
+
+    @Test
+    public void runDetoxTests() {
+        DetoxConfig detoxConfig = new DetoxConfig();
+        detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
+        detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
+        detoxConfig.rnContextLoadTimeoutSec = (BuildConfig.DEBUG ? 180 : 60);
+
+        Detox.runTests(mActivityRule, detoxConfig);
+    }
+}
+`,
+      );
+
+      return config;
+    },
+  ]);
+}

--- a/plugins/withDetoxTestBuildType.js
+++ b/plugins/withDetoxTestBuildType.js
@@ -1,23 +1,32 @@
 const { withAppBuildGradle } = require('expo/config-plugins');
 
 /**
- * Expo config plugin that adds testBuildType support for Detox.
+ * Expo config plugin for Detox Android E2E testing.
  *
- * Without this, Android always builds debug test APKs regardless of
- * the -DtestBuildType flag. This plugin injects the necessary config
- * so `./gradlew assembleAndroidTest -DtestBuildType=release` builds
- * a release test APK that can instrument a release app.
+ * Adds two capabilities to the generated build.gradle:
+ * 1. testBuildType support: allows -DtestBuildType=release to build release test APKs
+ * 2. bundleInDebug support: allows -PbundleInDebug to embed the JS bundle in debug
+ *    builds, so E2E tests work in CI without a Metro dev server
  */
 module.exports = function withDetoxTestBuildType(config) {
   return withAppBuildGradle(config, (config) => {
-    const contents = config.modResults.contents;
-    if (contents.includes('testBuildType')) {
-      return config;
+    let contents = config.modResults.contents;
+
+    if (!contents.includes('testBuildType')) {
+      contents = contents.replace(
+        /defaultConfig\s*\{/,
+        `defaultConfig {\n        testBuildType System.getProperty('testBuildType', 'debug')`,
+      );
     }
-    config.modResults.contents = contents.replace(
-      /defaultConfig\s*\{/,
-      `defaultConfig {\n        testBuildType System.getProperty('testBuildType', 'debug')`,
-    );
+
+    if (!contents.includes('bundleInDebug')) {
+      contents = contents.replace(
+        /react \{/,
+        `react {\n    bundleInDebug = project.hasProperty('bundleInDebug')`,
+      );
+    }
+
+    config.modResults.contents = contents;
     return config;
   });
 };

--- a/plugins/withDetoxTestBuildType.js
+++ b/plugins/withDetoxTestBuildType.js
@@ -19,11 +19,12 @@ module.exports = function withDetoxTestBuildType(config) {
       );
     }
 
-    // RNGP uses a bundleIn map property, not a direct bundleInDebug field
-    if (!contents.includes('bundleIn')) {
+    // RNGP skips JS bundling for variants in debuggableVariants (default: ['debug']).
+    // When -PbundleInDebug is passed, clear the list so debug builds get a JS bundle.
+    if (!contents.includes('debuggableVariants')) {
       contents = contents.replace(
         /react \{/,
-        `react {\n    if (project.hasProperty('bundleInDebug')) {\n        bundleIn = ["debug": true]\n    }`,
+        `react {\n    if (project.hasProperty('bundleInDebug')) {\n        debuggableVariants = []\n    }`,
       );
     }
 


### PR DESCRIPTION
## Problem

Android E2E tests fail in CI with error: `Error: No device found matching --device Pixel 4`. The 'Pixel 4' hardware profile was removed from newer Android SDK command-line tools, preventing the AVD from being created and the emulator from booting. Without an emulator, Detox E2E tests cannot run.

Additionally, the emulator runs without hardware acceleration (KVM) on ubuntu-latest, causing extremely slow performance and frequent timeouts.

## Solution

- Remove the `profile: Pixel 4` parameter from the `reactivecircus/android-emulator-runner` action — this hardware profile no longer exists
- Add a KVM enablement step to enable hardware acceleration on the ubuntu runner
- Rename AVD from `Pixel_4_API_30` to `test_emulator_api_30` in both CI workflow and Detox config for consistency

## Testing

1. Push to the branch and let CI run
2. Verify the "Enable KVM" step in the `e2e-android` job succeeds
3. Verify the emulator creates the AVD without the "No device found" error
4. Verify the E2E tests complete and pass (should see the three home screen and scan button tests pass)